### PR TITLE
Exclude certain URLs for local linkchecks

### DIFF
--- a/docfx-utils.ps1
+++ b/docfx-utils.ps1
@@ -5,8 +5,7 @@ param
     [parameter(mandatory=$false)][switch][Alias("b")]$build,
     [parameter(mandatory=$false)][switch][Alias("d")]$doclinkchecker,
     [parameter(mandatory=$false)][string][Alias("l")]$lychee,
-    [parameter(mandatory=$false)][string][Alias("a")]$all,
-    [parameter(mandatory=$false)][switch][Alias("r")]$remote
+    [parameter(mandatory=$false)][string][Alias("a")]$all
 )
 
 # this is called removeartifacts instead of clean because clean might be already mean something in powershell?
@@ -19,16 +18,11 @@ function removeartifacts
 
 function build{.\build.ps1 --logLevel Suggestion --warningsAsErrors}
 
-function lychee($lycheePath, $remote)
+function lychee($lycheePath)
 {
     Write-Output "`nRunning lychee..."
     Write-Output "------------------------------------------`n"
-    if ($remote){ 
-        Invoke-Expression "& `"$lycheePath`" --no-progress --base _site --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* '_site/**/*.html'"
-    }
-    else{
-        Invoke-Expression "& `"$lycheePath`" --no-progress --base _site --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --exclude ^https://github\.com/open-ephys/onix1-bonsai-docs/blob/.*/#L1 '_site/**/*.html'"
-    }
+    Invoke-Expression "& `"$lycheePath`" --no-progress --base _site --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --exclude ^https://github\.com/open-ephys/onix1-bonsai-docs/blob/.*/#L1 '_site/**/*.html'"
     Write-Output "`n"
 }
 
@@ -45,7 +39,7 @@ if ($build){build}
 
 if ($doclinkchecker){doclinkchecker}
 
-if ($PSBoundParameters.ContainsKey("lychee")){lychee $lychee $remote}
+if ($PSBoundParameters.ContainsKey("lychee")){lychee $lychee}
 
 if ($PSBoundParameters.ContainsKey("all"))
 {
@@ -64,5 +58,5 @@ if ($PSBoundParameters.ContainsKey("all"))
     Start-Sleep -Seconds 2
     doclinkchecker
     Start-Sleep -Seconds 2
-    lychee $all $remote
+    lychee $all
 }

--- a/docfx-utils.ps1
+++ b/docfx-utils.ps1
@@ -4,27 +4,31 @@ param
     [parameter(mandatory=$false)][switch][Alias("c")]$clean,
     [parameter(mandatory=$false)][switch][Alias("b")]$build,
     [parameter(mandatory=$false)][switch][Alias("d")]$doclinkchecker,
-    [parameter(mandatory=$false)][string][Alias("l")]$linkcheck,
-    [parameter(mandatory=$false)][string][Alias("a")]$all
+    [parameter(mandatory=$false)][string][Alias("l")]$lychee,
+    [parameter(mandatory=$false)][string][Alias("a")]$all,
+    [parameter(mandatory=$false)][switch][Alias("r")]$remote
 )
 
 # this is called removeartifacts instead of clean because clean might be already mean something in powershell?
 function removeartifacts
 {
     $deletePaths = ".\workflows\**\*.svg", ".\workflows\hardware\**\*.svg", ".\workflows\**\*.bonsai.layout", ".\workflows\hardware\**\*.bonsai.layout", ".\api\*.yml", ".\api\.manifest", ".\_site\", ".\_raw\", ".\_view\", ".\src\onix-bonsai-onix1\artifacts\"
-
     foreach($deletePath in $deletePaths){if (Test-Path $deletePath){Remove-Item $deletePath -Recurse}}
     Write-Output ""
 }
 
 function build{.\build.ps1 --logLevel Suggestion --warningsAsErrors}
 
-function linkcheck 
+function lychee($lycheePath, $remote)
 {
-    param($lycheePath)
     Write-Output "`nRunning lychee..."
     Write-Output "------------------------------------------`n"
-    Invoke-Expression "& `"$lycheePath`" --no-progress --base _site --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* '_site/**/*.html'"
+    if ($remote){ 
+        Invoke-Expression "& `"$lycheePath`" --no-progress --base _site --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* '_site/**/*.html'"
+    }
+    else{
+        Invoke-Expression "& `"$lycheePath`" --no-progress --base _site --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --exclude ^https://github\.com/open-ephys/onix1-bonsai-docs/blob/.*/#L1 '_site/**/*.html'"
+    }
     Write-Output "`n"
 }
 
@@ -41,7 +45,7 @@ if ($build){build}
 
 if ($doclinkchecker){doclinkchecker}
 
-if ($PSBoundParameters.ContainsKey("linkcheck")){linkcheck($linkcheck)}
+if ($PSBoundParameters.ContainsKey("lychee")){lychee $lychee $remote}
 
 if ($PSBoundParameters.ContainsKey("all"))
 {

--- a/docfx-utils.ps1
+++ b/docfx-utils.ps1
@@ -64,5 +64,5 @@ if ($PSBoundParameters.ContainsKey("all"))
     Start-Sleep -Seconds 2
     doclinkchecker
     Start-Sleep -Seconds 2
-    linkcheck($all)
+    lychee $all $remote
 }


### PR DESCRIPTION
- branched github URLs being checked even though they don't exist until pushed. Those URLs are now optionally checked with the -r flag
- "linkcheck" -> "lychee" to distinguish the function that runs lychee linkchecks and the function that runs doclinkchecker linkchecks

Resolve #74 