### PR TITLE
Remove white space in enum tables

### DIFF
--- a/template/partials/enum.tmpl.partial
+++ b/template/partials/enum.tmpl.partial
@@ -8,23 +8,20 @@
 <h2>Fields</h2>
 
 <table>
-
   <tr>
     <th style="white-space: no-wrap">Field & Value</th>
     <th>Description</th>
   </tr>
-
   {{#oe.enum}}
   <tr>
     <td style="white-space: no-wrap">
-      <code>
-        {{{field&value}}}
-      </code>
-    </td>
-    <td>
-      {{{description}}}
-    </td>
+        <code>
+          {{{field&value}}}
+        </code>
+      </td>
+      <td class="tableFormat">
+        {{{description}}}
+      </td>
   </tr>
   {{/oe.enum}}
-
 </table>

--- a/template/partials/propertyTables.tmpl.partial
+++ b/template/partials/propertyTables.tmpl.partial
@@ -1,29 +1,23 @@
 <tr>
-
   <td style = "white-space: nowrap;">
     <code>{{{name}}}</code>
   </td>
-
   <td style = "white-space: nowrap;">
     {{{type}}}
   </td>
-
-  <td>
-    <div class="tableFormat">
-      {{#propertyDescription}}
-      {{{propertyDescription.text}}}
-      {{#hasEnum}}
-      <table>
-        {{#enum}}
-        <tr>
-          <td class="term"><code>{{{field&value}}}</code></td>
-          <td class="description">{{{enumDescription}}}</td>
-        </tr>
-        {{/enum}}
-      </table>
-      {{/hasEnum}}
-      {{/propertyDescription}}
-    </div>
+  <td class="tableFormat">
+    {{#propertyDescription}}
+    {{{propertyDescription.text}}}
+    {{#hasEnum}}
+    <table>
+      {{#enum}}
+      <tr>
+        <td class="term"><code>{{{field&value}}}</code></td>
+        <td class="description">{{{enumDescription}}}</td>
+      </tr>
+      {{/enum}}
+    </table>
+    {{/hasEnum}}
+    {{/propertyDescription}}
   </td>
-
 </tr>

--- a/template/public/main.css
+++ b/template/public/main.css
@@ -1,10 +1,10 @@
 @import "workflow.css";
 
-div.tableFormat *:last-child {
+.tableFormat *:last-child {
   margin-bottom: 0;
 }
 
-div.tableFormat table {
+.tableFormat table {
   display: grid;
   grid-template-columns: auto; 
   margin-top: 1rem; 
@@ -14,12 +14,12 @@ div.tableFormat table {
   border-collapse: collapse; 
 }
 
-div.tableFormat td {
+.tableFormat td {
   padding: 0;
   border: 0 hidden;
 }
 
-div.tableFormat td.term {
+.tableFormat td.term {
   /* !important tag prevents overrides from dotnet.css associated with:
    body[data-yaml-mime="ManagedReference"] article td.term, body[data-yaml-mime="ApiPage"] article td.term 
    important tags are not good practice*/
@@ -27,7 +27,7 @@ div.tableFormat td.term {
   white-space: nowrap;
 }
 
-div.tableFormat td.description {
+.tableFormat td.description {
   padding-left: 1rem;
 }
 


### PR DESCRIPTION
- Allow "tableFormat" css class to be used in other html elements that aren't div
- resolve #112