### PR TITLE
Add memory monitor to np1 example workflow

### DIFF
--- a/workflows/hardware/np1e/np1e.bonsai
+++ b/workflows/hardware/np1e/np1e.bonsai
@@ -204,6 +204,14 @@
           <EnableLed>true</EnableLed>
         </Builder>
       </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="onix1:MemoryMonitorData">
+          <onix1:DeviceName>BreakoutBoard/MemoryMonitor</onix1:DeviceName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>PercentUsed</Selector>
+      </Expression>
     </Nodes>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
@@ -222,6 +230,7 @@
       <Edge From="16" To="17" Label="Source1" />
       <Edge From="17" To="18" Label="Source1" />
       <Edge From="18" To="19" Label="Source1" />
+      <Edge From="20" To="21" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
Resolve #156 

I built it to confirm memory monitor shows up in the workflow - I think it's safe to approve and merge without you looking too much into it.