### PR TITLE
Use modern GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Builds and publishes the documentation website to gh-pages branch
+# Builds and publishes the documentation website
 name: Build docs
 
 on:
@@ -7,17 +7,21 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Setup .NET Core SDK
-        uses: actions/setup-dotnet@v4.0.0
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
 
@@ -44,6 +48,11 @@ jobs:
           name: _site
           path: _site
           if-no-files-found: error
+      
+      - name: Upload GitHub Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
 
   check:
     name: Check Links
@@ -65,27 +74,16 @@ jobs:
           fail: true
 
   deploy:
-    name: Deploy docs to gh-pages
+    name: Deploy docs
     runs-on: ubuntu-latest
     needs: [ build, check ]
     if: github.event_name == 'push'
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: _site
-          path: _site
+    
+    permissions:
+      # Both required by actions/deploy-pages
+      pages: write
+      id-token: write
       
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4.1.1
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: Publish to github pages
-        uses: peaceiris/actions-gh-pages@v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _site
-          force_orphan: true
-
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Remove unnecessary version specificity.

Before merging: Go to [the GitHub Pages settings](https://github.com/open-ephys/bonsai-onix1-docs/settings/pages) for this repo and change the build/deployment source to "GitHub Actions".

- Resolves #177 