### PR TITLE
Remove concurrency restriction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
     branches: [ main ]
 
-concurrency:
-  group: docs
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
In the actions file, there was a check that did not allow multiple actions to be running concurrently. However, when we have multiple PRs there is a possibility that changes will be pushed to more than one simultaneously leading to one of the actions being prematurely cancelled. This is especially a problem due to how long it takes the actions to run from scratch for the actions. 

This PR removes that restriction.