### PR TITLE
Fix np2 scaling factor

### DIFF
--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -36,7 +36,7 @@ plt.tight_layout()
 
 #%% Neuropixels 2.0 Data
 bit_depth = 12
-scalar = 2.44141
+scalar = 3.05176
 offset = -(2 ** (bit_depth - 1)) * scalar
 recording = se.read_binary(os.path.join(data_directory,  f"np2-a-ephys_{suffix}.raw"), 
                            3e5, 


### PR DESCRIPTION
I believe the previous scaling factor was result from misleading information from np2 datasheet. The updated one is the value empirically measured.