### PR TITLE
Simplify npx data-loading scripts & fix parameters for loading data

### DIFF
--- a/articles/hardware/hs64/load-data.md
+++ b/articles/hardware/hs64/load-data.md
@@ -3,7 +3,8 @@ uid: hs64_load-data
 title: Load Data
 ---
 
-The following python script can be used to load and plot the data produced by the Headstage 64 [example workflow](xref:hs64_workflow).
+The following python script can be used to load and plot the data produced by the Headstage 64
+[example workflow](xref:hs64_workflow).
 
 [!code-python[](../../../workflows/hardware/hs64/load-hs64.py)]
 

--- a/articles/hardware/np1e/load-data.md
+++ b/articles/hardware/np1e/load-data.md
@@ -3,15 +3,15 @@ uid: np1e_load-data
 title: Load Data
 ---
 
-The following python script can be used to load and plot the data produced by the NeuropixelsV1e Headstage [example workflow](xref:np1e).
+The following python script can be used to load and plot the data produced by the NeuropixelsV1e
+Headstage [example workflow](xref:np1e).
 
 [!code-python[](../../../workflows/hardware/np1e/load-np1e.py)]
 
 > [!NOTE]
-> To plot probeinterface data, [save the probe configuration file](xref:np1e_gui#save-probeinterface-file) into the same directory of your data.
-
-> [!NOTE]
-> This script will attempt to load entire files into arrays. For long recordings, data will need to
-> be split into more manageable chunks by:
-> - Modifying this script to partially load files
-> - Modifying the workflow to cyclically create new files after a certain duration
+> - To plot probeinterface data, [save the probe configuration file](xref:np1e_gui#save-probeinterface-file) 
+>   into the same directory of your data.
+> - This script will attempt to load entire files into arrays. For long recordings, data will need to
+>   be split into more manageable chunks by:
+>   - Modifying this script to partially load files
+>   - Modifying the workflow to cyclically create new files after a certain duration

--- a/articles/hardware/np2e/load-data.md
+++ b/articles/hardware/np2e/load-data.md
@@ -11,6 +11,9 @@ Headstage [example workflow](xref:np2e).
 > [!NOTE]
 > - To plot probeinterface data, [save the probe configuration file](xref:np2e_gui#save-probeinterface-file) 
 >   into the same directory of your data.
+> - By default, this script only populates plots for the Neuropixels 2.0 probe A and leaves plots
+>   for Neuropixels 2.0 probe B empty. If you are recording from both probes and want to plot probe
+>   B ephys and probe data, uncomment the relevant lines in the script.
 > - This script will attempt to load entire files into arrays. For long recordings, data will need to
 >   be split into more manageable chunks by:
 >   - Modifying this script to partially load files

--- a/articles/hardware/np2e/load-data.md
+++ b/articles/hardware/np2e/load-data.md
@@ -3,15 +3,15 @@ uid: np2e_load-data
 title: Load Data
 ---
 
-The following python script can be used to load and plot the data produced by the NeuropixelsV1e Headstage [example workflow](xref:np2e).
+The following python script can be used to load and plot the data produced by the NeuropixelsV2e
+Headstage [example workflow](xref:np2e).
 
 [!code-python[](../../../workflows/hardware/np2e/load-np2e.py)]
 
 > [!NOTE]
-> To plot probeinterface data, [save the probe configuration file](xref:np2e_gui#save-probeinterface-file) into the same directory of your data.
-
-> [!NOTE]
-> This script will attempt to load entire files into arrays. For long recordings, data will need to
-> be split into more manageable chunks by:
-> - Modifying this script to partially load files
-> - Modifying the workflow to cyclically create new files after a certain duration
+> - To plot probeinterface data, [save the probe configuration file](xref:np2e_gui#save-probeinterface-file) 
+>   into the same directory of your data.
+> - This script will attempt to load entire files into arrays. For long recordings, data will need to
+>   be split into more manageable chunks by:
+>   - Modifying this script to partially load files
+>   - Modifying the workflow to cyclically create new files after a certain duration

--- a/articles/hardware/rhs2116/load-data.md
+++ b/articles/hardware/rhs2116/load-data.md
@@ -3,7 +3,8 @@ uid: rhs2116_load-data
 title: Load Data
 ---
 
-The following python script can be used to load and plot the data produced by the Headstage Rhs2116 [example workflow](xref:rhs2116).
+The following python script can be used to load and plot the data produced by the Headstage Rhs2116
+[example workflow](xref:rhs2116).
 
 [!code-python[](../../../workflows/hardware/rhs2116/load-rhs2116.py)]
 

--- a/workflows/hardware/hs64/load-hs64.py
+++ b/workflows/hardware/hs64/load-hs64.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 suffix = 0                                                 # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/hs64' # Change to match files' directory
 plot_num_channels = 10                                     # Number of channels to plot
-start_t = 5.0                                              # Plot start time (seconds)
+start_t = 3.0                                              # Plot start time (seconds)
 dur = 2.0                                                  # Plot time duration (seconds)
 
 # RHD2164 constants

--- a/workflows/hardware/hs64/load-hs64.py
+++ b/workflows/hardware/hs64/load-hs64.py
@@ -1,127 +1,116 @@
+# Import necessary packages
 import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-# Load data from headstage64 tutorial workflow
-suffix = '0'; # Change to match file names' suffix
-# Change this to the directory of your data. In this example, data's in the same directory as this data loading Python script
-data_directory = os.path.dirname(os.path.realpath(__file__))
-start_t = 1.0 # when to start plotting data (seconds)
-dur = 1.0 # duration of data to plot
+#%% Set parameters for loading data
 
-plt.close('all')
+suffix = 0                                                 # Change to match filenames' suffix
+data_directory = 'C:/Users/open-ephys/Documents/data/hs64' # Change to match files' directory
+plot_num_channels = 10                                     # Number of channels to plot
 
-#%% Metadata
+# RHD2164 constants
+ephys_uV_multiplier = 0.195
+aux_uV_multiplier = 37.4
+offset = 32768
+num_channels = 64
+
+#%%  Load acquisition session data
+
 dt = {'names': ('time', 'acq_clk_hz', 'block_read_sz', 'block_write_sz'),
       'formats': ('datetime64[us]', 'u4', 'u4', 'u4')}
 meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt, skip_header=1)
-print(f"Recording was started at {meta['time']} GMT")
+print(f'Recording was started at {meta["time"]} GMT')
+print(f'Acquisition clock rate was {meta["acq_clk_hz"] / 1e6 } MHz')
 
-#%% RHD2164 ephys data
-start_t = 1.0 # when to start plotting data (seconds)
-dur = 1.0 # duration of data to plot
-plot_channel_offset_uV = 1000 # Vertical offset between each channel in the time series
+#%% Load RHD2164 data
 
-hs64 = {}
-hs64['time'] = np.fromfile(os.path.join(data_directory, f'rhd2164-clock_{suffix}.raw'), dtype=np.uint64) / meta['acq_clk_hz']
-hs64['ephys'] = np.reshape(np.fromfile(os.path.join(data_directory, f'rhd2164-ephys_{suffix}.raw'), dtype=np.uint16), (-1, 64))
+rhd2164 = {}
 
-# Make arrays for plotting
-b = np.bitwise_and(hs64['time'] >= start_t, hs64['time'] < start_t + dur)
-time = hs64['time'][b]
-rhd2164_ephys = hs64['ephys'][b, :].astype(np.double)
+# Load RHD2164 clock data and convert clock cycles to seconds
+rhd2164['time'] = np.fromfile(os.path.join(data_directory, f'rhd2164-clock_{suffix}.raw'), dtype=np.uint64) / meta['acq_clk_hz']
 
-# Convert to uV and offset each channel by some plot_channel_offset_uV 
-bit_depth = 16
-scalar = 0.195
-offset = (2 ** (bit_depth - 1)) * scalar
-rhd2164_ephys = rhd2164_ephys * scalar - offset + np.arange(rhd2164_ephys.shape[1])[None, :] * offset / 4
+# Load and scale RHD2164 ephys data
+ephys = np.reshape(np.fromfile(os.path.join(data_directory, f'rhd2164-ephys_{suffix}.raw'), dtype=np.uint16), (-1, num_channels))
+rhd2164['ephys_uV'] = (ephys.astype(np.float32) - offset) * ephys_uV_multiplier
 
-fig = plt.figure()
-plt.plot(time, rhd2164_ephys, 'k', linewidth=0.25)
-plt.tick_params(axis='y', which='both', left=False, right=False, labelleft=False) 
-plt.xlabel("time (sec)")
-plt.ylabel("channel")
-plt.title('RHD2164 Ephys Data')
-fig.set_size_inches(5,8)
-plt.tight_layout()
+# Load and scale RHD2164 aux data
+aux = np.reshape(np.fromfile(os.path.join(data_directory, f'rhd2164-aux_{suffix}.raw'), dtype=np.uint16), (-1, 3))
+rhd2164['aux_uV'] = (aux.astype(np.float32) - offset) * aux_uV_multiplier
 
-#%% RHD2164 aux data
-hs64['aux'] = np.reshape(np.fromfile(os.path.join(data_directory, f'rhd2164-aux_{suffix}.raw'), dtype=np.uint16), (-1, 3))
+#%% Load BNO055 data
 
-# Make arrays for plotting
-b = np.bitwise_and(hs64['time'] >= start_t, hs64['time'] < start_t + dur)
-time = hs64['time'][b]
-rhd2164_aux = hs64['aux'][b, :].astype(np.double)
-
-# Convert to uV and offset each channel by some plot_channel_offset_uV 
-scalar = 37.4
-rhd2164_aux_wave = (rhd2164_aux - 2 **(bit_depth - 1)) * scalar
-
-plt.figure()
-plt.plot(time, rhd2164_aux_wave)
-plt.xlabel("time (sec)")
-plt.ylabel("channel")
-plt.title('RHD2164 Auxiliary Data')
-
-#%% Bno055
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
       'formats': ('u8', '(1,3)f8', '(1,4)f8', '?', '(1,3)f8', '(1,3)f8', 'f8')}
 bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), delimiter=',', dtype=dt)
 
+# Convert clock cycles to seconds
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
-plt.figure()
+#%% Load TS4231 data
 
-plt.subplot(231)
-plt.plot(bno055_time, bno055['euler'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("angle (deg.)")
-plt.ylim(-185, 365)
-plt.legend(['yaw', 'pitch', 'roll'])
-plt.title('Euler')
-
-plt.subplot(232)
-plt.plot(bno055_time, bno055['quat'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylim(-1.1, 1.1)
-plt.legend(['X', 'Y', 'Z', 'W'])
-plt.title('Quaternion')
-
-plt.subplot(233)
-plt.plot(bno055_time, bno055['accel'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("accel. (m/s^2)")
-plt.legend(['X', 'Y', 'Z'])
-plt.title('Lin. Accel.')
-
-plt.subplot(234)
-plt.plot(bno055_time, bno055['grav'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("accel. (m/s^2)")
-plt.legend(['X', 'Y', 'Z'])
-plt.title('Gravity Vec.')
-
-plt.subplot(235)
-plt.plot(bno055_time, bno055['temp'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("temp. (°C)")
-plt.title('Headstage Temp.')
-
-plt.tight_layout()
-
-#%% TS4231
+# Load TS4231 data
 dt = {'names': ('clock', 'position'),
       'formats': ('u8', '(1,3)f8')}
 ts4231 = np.genfromtxt(os.path.join(data_directory, f'ts4231_{suffix}.csv'), delimiter=',', dtype=dt)
 
+# Convert clock cycles to seconds
 ts4231_time = ts4231['clock'] / meta['acq_clk_hz']
-plt.figure()
 
+#%% Plot time series
+
+fig = plt.figure(figsize=(12, 10))
+
+# Plot RHD2164 ephys data
+plt.subplot(711)
+plt.plot(rhd2164['time'], rhd2164['ephys_uV'][:,0:plot_num_channels])
+plt.xlabel('Time (seconds)')
+plt.ylabel('Voltage (µV)')
+plt.title('RHD2164 Ephys Data')
+
+# Plot RHD2164 aux data
+plt.subplot(712)
+plt.plot(rhd2164['time'], rhd2164['aux_uV'])
+plt.xlabel('Time (seconds)')
+plt.ylabel('Voltage (µV)')
+plt.title('RHD2164 Aux Data')
+
+# Plot BNO055 data
+plt.subplot(713)
+plt.plot(bno055_time, bno055['euler'].squeeze())
+plt.xlabel('Time (seconds)')
+plt.ylabel('degrees')
+plt.title('Euler Angles')
+plt.legend(['Yaw', 'Pitch', 'Roll'])
+
+plt.subplot(714)
+plt.plot(bno055_time, bno055['quat'].squeeze())
+plt.xlabel('Time (seconds)')
+plt.title('Quaternion')
+plt.legend(['X', 'Y', 'Z', 'W'])
+
+plt.subplot(715)
+plt.plot(bno055_time, bno055['accel'].squeeze())
+plt.xlabel('Time (seconds)')
+plt.ylabel('m/s\u00b2')
+plt.title('Linear Acceleration')
+plt.legend(['X', 'Y', 'Z'])
+
+plt.subplot(716)
+plt.plot(bno055_time, bno055['grav'].squeeze())
+plt.xlabel('Time (seconds)')
+plt.ylabel('m/s\u00b2')
+plt.title('Gravity Vector')
+plt.legend(['X', 'Y', 'Z'])
+
+# Plot TS4231 data
+plt.subplot(717)
 plt.plot(ts4231_time, ts4231['position'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("position (units)")
-plt.legend(['x', 'y', 'z'])
+plt.xlabel('Time (seconds)')
+plt.ylabel('Position (units)')
 plt.title('Position Data')
+plt.legend(['X', 'Y', 'Z'])
+
+fig.tight_layout()
 
 plt.show()

--- a/workflows/hardware/hs64/load-hs64.py
+++ b/workflows/hardware/hs64/load-hs64.py
@@ -8,6 +8,8 @@ import matplotlib.pyplot as plt
 suffix = 0                                                 # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/hs64' # Change to match files' directory
 plot_num_channels = 10                                     # Number of channels to plot
+start_t = 5.0                                              # Plot start time (seconds)
+dur = 2.0                                                  # Plot time duration (seconds)
 
 # RHD2164 constants
 ephys_uV_multiplier = 0.195
@@ -38,6 +40,8 @@ rhd2164['ephys_uV'] = (ephys.astype(np.float32) - offset) * ephys_uV_multiplier
 aux = np.reshape(np.fromfile(os.path.join(data_directory, f'rhd2164-aux_{suffix}.raw'), dtype=np.uint16), (-1, 3))
 rhd2164['aux_uV'] = (aux.astype(np.float32) - offset) * aux_uV_multiplier
 
+rhd2164_time_mask = np.bitwise_and(rhd2164['time'] >= start_t, rhd2164['time'] < start_t + dur)
+
 #%% Load BNO055 data
 
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
@@ -46,6 +50,8 @@ bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), del
 
 # Convert clock cycles to seconds
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
+
+bno055_time_mask = np.bitwise_and(bno055_time >= start_t, bno055_time < start_t + dur)
 
 #%% Load TS4231 data
 
@@ -57,47 +63,49 @@ ts4231 = np.genfromtxt(os.path.join(data_directory, f'ts4231_{suffix}.csv'), del
 # Convert clock cycles to seconds
 ts4231_time = ts4231['clock'] / meta['acq_clk_hz']
 
+ts4231_time_mask = np.bitwise_and(ts4231_time >= start_t, ts4231_time < start_t + dur)
+
 #%% Plot time series
 
 fig = plt.figure(figsize=(12, 10))
 
 # Plot RHD2164 ephys data
 plt.subplot(711)
-plt.plot(rhd2164['time'], rhd2164['ephys_uV'][:,0:plot_num_channels])
+plt.plot(rhd2164['time'][rhd2164_time_mask], rhd2164['ephys_uV'][:,0:plot_num_channels][rhd2164_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('Voltage (µV)')
 plt.title('RHD2164 Ephys Data')
 
 # Plot RHD2164 aux data
 plt.subplot(712)
-plt.plot(rhd2164['time'], rhd2164['aux_uV'])
+plt.plot(rhd2164['time'][rhd2164_time_mask], rhd2164['aux_uV'][rhd2164_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('Voltage (µV)')
 plt.title('RHD2164 Aux Data')
 
 # Plot BNO055 data
 plt.subplot(713)
-plt.plot(bno055_time, bno055['euler'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['euler'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('degrees')
 plt.title('Euler Angles')
 plt.legend(['Yaw', 'Pitch', 'Roll'])
 
 plt.subplot(714)
-plt.plot(bno055_time, bno055['quat'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['quat'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.title('Quaternion')
 plt.legend(['X', 'Y', 'Z', 'W'])
 
 plt.subplot(715)
-plt.plot(bno055_time, bno055['accel'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['accel'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Linear Acceleration')
 plt.legend(['X', 'Y', 'Z'])
 
 plt.subplot(716)
-plt.plot(bno055_time, bno055['grav'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['grav'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Gravity Vector')
@@ -105,7 +113,7 @@ plt.legend(['X', 'Y', 'Z'])
 
 # Plot TS4231 data
 plt.subplot(717)
-plt.plot(ts4231_time, ts4231['position'].squeeze())
+plt.plot(ts4231_time[ts4231_time_mask], ts4231['position'].squeeze()[ts4231_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('Position (units)')
 plt.title('Position Data')

--- a/workflows/hardware/np1e/load-np1e.py
+++ b/workflows/hardware/np1e/load-np1e.py
@@ -1,129 +1,117 @@
+# Import necessary packages
 import os
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
 import spikeinterface.extractors as se
-import spikeinterface.widgets as sw
 import probeinterface
 import probeinterface.plotting
 
-ap_gain = 500 # Change to the ap band gain used
-lfp_gain = 500 # Change to the lfp band gain used
-suffix = 0 # Change to match file names' suffix
-num_channels = 384 # Decrease channels to expedite plotting and inspect fewer traces
-# Change this to the directory of your data. In this example, data's in the same directory as this data loading Python script
-data_directory = os.path.dirname(os.path.realpath(__file__))
-mode = 'auto' # This uses colormap plot above 50 channels and line plot below 50 channels. Refer to the spikeinterface docs for more options
-# Change this to the name of your probeinterface file (should be in the same directory as the rest of your data for this example script to work as-is)
-probeinterface_filename = 'np1-config.json'
+# Parameters
+suffix = 0                                                 # Change to match file names' suffix
+data_directory = 'C:/Users/open-ephys/Documents/data/np1e' # Change to match files' directory
+plot_num_channels = 10                                     # Number of channels to plot
+ap_gain = 1000                                             # Change to the ap band gain used
+lfp_gain = 50                                              # Change to the lfp band gain used
 
+# Constants
+fs_hz_ap = 30e3
+fs_hz_lfp = fs_hz_ap / 12
+sample_offset = 512
+sample_gain = 1171.875
+num_channels = 384
 
-plt.close('all')
-
-#%% Metadata
+# Load acquisition session data
 dt = {'names': ('time', 'acq_clk_hz', 'block_read_sz', 'block_write_sz'),
       'formats': ('datetime64[us]', 'u4', 'u4', 'u4')}
 meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt, skip_header=1)
-print(f"Recording was started at {meta['time']} GMT")
+print(f'Recording was started at {meta["time"]} GMT')
+print(f'Acquisition clock rate was {meta["acq_clk_hz"] / 1e6 } MHz')
 
-#%% Neuropixels 1.0 probeinterface
-fig, ax = plt.subplots()
-np1_config = probeinterface.io.read_probeinterface(os.path.join(data_directory,  'np1-config.json'))
-contacts_colors = ['cyan' if device_channel_index > -1 else 'red' for device_channel_index in np1_config.probes[0].device_channel_indices]
-probeinterface.plotting.plot_probegroup(np1_config, ax=ax, contacts_colors=contacts_colors, contacts_kargs={'alpha' : 1, 'zorder' : 10}, show_channel_on_click=True)
-fig.set_size_inches(2, 9)
-enabled = mpatches.Patch(color='cyan', label='Enabled')
-disabled = mpatches.Patch(color='red', label='Disabled')
-fig.legend(handles=[enabled, disabled], loc='outside upper center') 
-plt.tight_layout()
+# Load Neuropixels 1.0 AP clock data
+ap_time = np.fromfile(os.path.join(data_directory, f'np1-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
 
+# Load and scale Neuropixels 1.0 AP data
+gain_to_uV_ap = sample_gain / ap_gain
+offset_to_uV_ap = -sample_offset * gain_to_uV_ap
+ap_rec = se.read_binary(os.path.join(data_directory, f'np1-spike_{suffix}.raw'),
+                        sampling_frequency=fs_hz_ap,
+                        dtype=np.uint16,
+                        num_channels=num_channels,
+                        gain_to_uV=gain_to_uV_ap,
+                        offset_to_uV=offset_to_uV_ap)
+ap_scaled = ap_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
-#%% Neuropixels 1.0 Data
-bit_depth = 10
-fig, ax = plt.subplots(1,2)
-fig.suptitle('Neuropixels 1.0 Data')
-fig.set_size_inches(9, 9)
-plt.subplots_adjust(wspace=0.3)
+# Load Neuropixels 1.0 LFP clock data. The LFP is sampled every at 1/12th the rate of AP data
+lfp_time = ap_time[::12]
 
-ap_scalar = 1.2e6 / (2 ** bit_depth) / ap_gain
-ap_offset = (2 ** (bit_depth - 1)) * ap_scalar
-ap_recording = se.read_binary(os.path.join(data_directory,  f"np1-spike_{suffix}.raw"), 
-                           3e5, 
-                           np.uint16, 
-                           num_channels, 
-                           gain_to_uV=ap_scalar, 
-                           offset_to_uV=-ap_offset) 
-ap_traces_plot = sw.plot_traces(ap_recording, 
-                   backend='matplotlib', 
-                   return_scaled=True, 
-                   mode=mode, 
-                   clim=(-ap_offset,ap_offset),
-                   ax=ax[0])
-ax[0].set_xlabel("time (sec)")
-ax[0].set_ylabel("AP (µV)")
+# Load and scale Neuropixels 1.0 LFP data
+gain_to_uV_lfp = sample_gain / lfp_gain
+offset_to_uV_lfp = -sample_offset * gain_to_uV_lfp
+lfp_rec = se.read_binary(os.path.join(data_directory, f'np1-lfp_{suffix}.raw'),
+                         sampling_frequency=fs_hz_lfp,
+                         dtype=np.uint16,
+                         num_channels=num_channels,
+                         gain_to_uV=gain_to_uV_lfp,
+                         offset_to_uV=offset_to_uV_lfp)
+lfp_scaled = lfp_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
-lfp_scalar = 1.2e6 / (2 ** bit_depth) / lfp_gain
-lfp_offset = (2 ** (bit_depth - 1)) * lfp_scalar
-lfp_recording = se.read_binary(os.path.join(data_directory,  f"np1-lfp_{suffix}.raw"), 
-                           3e5/12, 
-                           np.uint16, 
-                           num_channels, 
-                           gain_to_uV=lfp_scalar, 
-                           offset_to_uV=-lfp_offset) 
-lfp_traces_plot = sw.plot_traces(lfp_recording, 
-                   backend='matplotlib', 
-                   return_scaled=True, 
-                   mode=mode, 
-                   clim=(-lfp_offset,lfp_offset), 
-                  ax=ax[1])
-ax[1].set_xlabel("time (sec)")
-ax[1].set_ylabel("LFP (µV)")
-
-#%% Bno055
+# Load BNO055 data
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
-      'formats': ('u8', '(1,3)f8', '(1,4)f8', '?', '(1,3)f8', '(1,3)f8', 'f8', '?')}
+      'formats': ('u8', '(1,3)f8', '(1,4)f8', '?', '(1,3)f8', '(1,3)f8', 'f8')}
 bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), delimiter=',', dtype=dt)
 
+# BNO055 time data
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
-plt.figure()
-plt.subplot(231)
+# Plot time series
+fig = plt.figure(figsize=(12, 8))
+
+# Plot scaled Neuropixels 1.0 AP data
+plt.subplot(611)
+plt.plot(ap_time, ap_scaled)
+plt.xlabel('Time (seconds)')
+plt.ylabel('µV')
+plt.title('AP Band Voltage')
+
+# Plot scaled Neuropixels 1.0 LFP data
+plt.subplot(612)
+plt.plot(lfp_time, lfp_scaled)
+plt.xlabel('Time (seconds)')
+plt.ylabel('µV')
+plt.title('LFP Band Voltage')
+
+# Plot BNO055 data
+plt.subplot(613)
 plt.plot(bno055_time, bno055['euler'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("angle (deg.)")
-plt.ylim(-185, 365)
-plt.legend(['yaw', 'pitch', 'roll'])
-plt.title('Euler')
+plt.xlabel('Time (seconds)')
+plt.ylabel('degrees')
+plt.title('Euler Angles')
+plt.legend(['Yaw', 'Pitch', 'Roll'])
 
-plt.subplot(232)
+plt.subplot(614)
 plt.plot(bno055_time, bno055['quat'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylim(-1.1, 1.1)
-plt.legend(['X', 'Y', 'Z', 'W'])
+plt.xlabel('Time (seconds)')
 plt.title('Quaternion')
+plt.legend(['X', 'Y', 'Z', 'W'])
 
-plt.subplot(233)
+plt.subplot(615)
 plt.plot(bno055_time, bno055['accel'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("accel. (m/s^2)")
+plt.xlabel('Time (seconds)')
+plt.ylabel('m/s\u00b2')
+plt.title('Linear Acceleration')
 plt.legend(['X', 'Y', 'Z'])
-plt.title('Lin. Accel.')
 
-plt.subplot(234)
+plt.subplot(616)
 plt.plot(bno055_time, bno055['grav'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("accel. (m/s^2)")
+plt.xlabel('Time (seconds)')
+plt.ylabel('m/s\u00b2')
+plt.title('Gravity Vector')
 plt.legend(['X', 'Y', 'Z'])
-plt.title('Gravity Vec.')
 
-plt.subplot(235)
-plt.plot(bno055_time, bno055['temp'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("temp. (°C)")
-plt.title('Headstage Temp.')
+fig.tight_layout()
 
-plt.tight_layout()
+# Load and plot Neuropixels 1.0 probeinterface probe group
+np1_config = probeinterface.io.read_probeinterface(os.path.join(data_directory, f'np1-config.json'))
+probeinterface.plotting.plot_probegroup(np1_config, show_channel_on_click=True)
 
 plt.show()
-
-fig.suptitle('BNO055 Data')

--- a/workflows/hardware/np1e/load-np1e.py
+++ b/workflows/hardware/np1e/load-np1e.py
@@ -13,7 +13,7 @@ data_directory = 'C:/Users/open-ephys/Documents/data/np1e' # Change to match fil
 plot_num_channels = 10                                     # Number of channels to plot
 ap_gain = 1000                                             # Change to the ap band gain used
 lfp_gain = 50                                              # Change to the lfp band gain used
-start_t = 5.0                                              # Plot start time (seconds)
+start_t = 3.0                                              # Plot start time (seconds)
 dur = 2.0                                                  # Plot time duration (seconds)
 
 # Neuropixels 1.0 constants
@@ -128,9 +128,7 @@ fig.tight_layout()
 
 #%% Load and plot Neuropixels 1.0 probeinterface probe group
 
-fig = plt.figure(figsize=(3, 8))
-fig.add_subplot()
 np1_config = probeinterface.io.read_probeinterface(os.path.join(data_directory, f'np1-config.json'))
-probeinterface.plotting.plot_probegroup(np1_config, show_channel_on_click=True, ax=fig.axes[0])
+probeinterface.plotting.plot_probegroup(np1_config, show_channel_on_click=True)
 
 plt.show()

--- a/workflows/hardware/np1e/load-np1e.py
+++ b/workflows/hardware/np1e/load-np1e.py
@@ -13,6 +13,8 @@ data_directory = 'C:/Users/open-ephys/Documents/data/np1e' # Change to match fil
 plot_num_channels = 10                                     # Number of channels to plot
 ap_gain = 1000                                             # Change to the ap band gain used
 lfp_gain = 50                                              # Change to the lfp band gain used
+start_t = 5.0                                              # Plot start time (seconds)
+dur = 2.0                                                  # Plot time duration (seconds)
 
 # Neuropixels 1.0 constants
 fs_hz_ap = 30e3
@@ -47,6 +49,8 @@ ap_rec = se.read_binary(os.path.join(data_directory, f'np1-spike_{suffix}.raw'),
                         offset_to_uV=offset_to_uV_ap)
 np1['ap_uV'] = ap_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
+ap_time_mask = np.bitwise_and(np1['ap_time'] >= start_t, np1['ap_time'] < start_t + dur)
+
 # Load Neuropixels 1.0 LFP clock data. The LFP is sampled every at 1/12th the rate of AP data
 np1['lfp_time'] = np1['ap_time'][::12]
 
@@ -61,6 +65,8 @@ lfp_rec = se.read_binary(os.path.join(data_directory, f'np1-lfp_{suffix}.raw'),
                          offset_to_uV=offset_to_uV_lfp)
 np1['lfp_uV'] = lfp_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
+lfp_time_mask = np.bitwise_and(np1['lfp_time'] >= start_t, np1['lfp_time'] < start_t + dur)
+
 #%% Load BNO055 data
 
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
@@ -70,47 +76,49 @@ bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), del
 # Convert clock cycles to seconds
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
+bno055_time_mask = np.bitwise_and(bno055_time >= start_t, bno055_time < start_t + dur)
+
 #%% Plot time series
 
 fig = plt.figure(figsize=(12, 8))
 
 # Plot scaled Neuropixels 1.0 AP data
 plt.subplot(611)
-plt.plot(np1['ap_time'], np1['ap_uV'])
+plt.plot(np1['ap_time'][ap_time_mask], np1['ap_uV'][ap_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
 plt.title('AP Band Voltage')
 
 # Plot scaled Neuropixels 1.0 LFP data
 plt.subplot(612)
-plt.plot(np1['lfp_time'], np1['lfp_uV'])
+plt.plot(np1['lfp_time'][lfp_time_mask], np1['lfp_uV'][lfp_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
 plt.title('LFP Band Voltage')
 
 # Plot BNO055 data
 plt.subplot(613)
-plt.plot(bno055_time, bno055['euler'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['euler'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('degrees')
 plt.title('Euler Angles')
 plt.legend(['Yaw', 'Pitch', 'Roll'])
 
 plt.subplot(614)
-plt.plot(bno055_time, bno055['quat'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['quat'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.title('Quaternion')
 plt.legend(['X', 'Y', 'Z', 'W'])
 
 plt.subplot(615)
-plt.plot(bno055_time, bno055['accel'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['accel'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Linear Acceleration')
 plt.legend(['X', 'Y', 'Z'])
 
 plt.subplot(616)
-plt.plot(bno055_time, bno055['grav'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['grav'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Gravity Vector')

--- a/workflows/hardware/np1e/load-np1e.py
+++ b/workflows/hardware/np1e/load-np1e.py
@@ -6,29 +6,35 @@ import spikeinterface.extractors as se
 import probeinterface
 import probeinterface.plotting
 
-# Parameters
-suffix = 0                                                 # Change to match file names' suffix
+#%% Set parameters for loading data
+
+suffix = 0                                                 # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/np1e' # Change to match files' directory
 plot_num_channels = 10                                     # Number of channels to plot
 ap_gain = 1000                                             # Change to the ap band gain used
 lfp_gain = 50                                              # Change to the lfp band gain used
 
-# Constants
+# Neuropixels 1.0 constants
 fs_hz_ap = 30e3
 fs_hz_lfp = fs_hz_ap / 12
 sample_offset = 512
 sample_gain = 1171.875
 num_channels = 384
 
-# Load acquisition session data
+#%%  Load acquisition session data
+
 dt = {'names': ('time', 'acq_clk_hz', 'block_read_sz', 'block_write_sz'),
       'formats': ('datetime64[us]', 'u4', 'u4', 'u4')}
 meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt, skip_header=1)
 print(f'Recording was started at {meta["time"]} GMT')
 print(f'Acquisition clock rate was {meta["acq_clk_hz"] / 1e6 } MHz')
 
-# Load Neuropixels 1.0 AP clock data
-ap_time = np.fromfile(os.path.join(data_directory, f'np1-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
+#%% Load Neuropixels 1.0 probe data
+
+np1 = {}
+
+# Load Neuropixels 1.0 AP clock data and convert clock cycles to seconds
+np1['ap_time'] = np.fromfile(os.path.join(data_directory, f'np1-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
 
 # Load and scale Neuropixels 1.0 AP data
 gain_to_uV_ap = sample_gain / ap_gain
@@ -39,10 +45,10 @@ ap_rec = se.read_binary(os.path.join(data_directory, f'np1-spike_{suffix}.raw'),
                         num_channels=num_channels,
                         gain_to_uV=gain_to_uV_ap,
                         offset_to_uV=offset_to_uV_ap)
-ap_scaled = ap_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
+np1['ap_uV'] = ap_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
 # Load Neuropixels 1.0 LFP clock data. The LFP is sampled every at 1/12th the rate of AP data
-lfp_time = ap_time[::12]
+np1['lfp_time'] = np1['ap_time'][::12]
 
 # Load and scale Neuropixels 1.0 LFP data
 gain_to_uV_lfp = sample_gain / lfp_gain
@@ -53,29 +59,31 @@ lfp_rec = se.read_binary(os.path.join(data_directory, f'np1-lfp_{suffix}.raw'),
                          num_channels=num_channels,
                          gain_to_uV=gain_to_uV_lfp,
                          offset_to_uV=offset_to_uV_lfp)
-lfp_scaled = lfp_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
+np1['lfp_uV'] = lfp_rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
-# Load BNO055 data
+#%% Load BNO055 data
+
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
       'formats': ('u8', '(1,3)f8', '(1,4)f8', '?', '(1,3)f8', '(1,3)f8', 'f8')}
 bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), delimiter=',', dtype=dt)
 
-# BNO055 time data
+# Convert clock cycles to seconds
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
-# Plot time series
+#%% Plot time series
+
 fig = plt.figure(figsize=(12, 8))
 
 # Plot scaled Neuropixels 1.0 AP data
 plt.subplot(611)
-plt.plot(ap_time, ap_scaled)
+plt.plot(np1['ap_time'], np1['ap_uV'])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
 plt.title('AP Band Voltage')
 
 # Plot scaled Neuropixels 1.0 LFP data
 plt.subplot(612)
-plt.plot(lfp_time, lfp_scaled)
+plt.plot(np1['lfp_time'], np1['lfp_uV'])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
 plt.title('LFP Band Voltage')
@@ -110,8 +118,11 @@ plt.legend(['X', 'Y', 'Z'])
 
 fig.tight_layout()
 
-# Load and plot Neuropixels 1.0 probeinterface probe group
+#%% Load and plot Neuropixels 1.0 probeinterface probe group
+
+fig = plt.figure(figsize=(3, 8))
+fig.add_subplot()
 np1_config = probeinterface.io.read_probeinterface(os.path.join(data_directory, f'np1-config.json'))
-probeinterface.plotting.plot_probegroup(np1_config, show_channel_on_click=True)
+probeinterface.plotting.plot_probegroup(np1_config, show_channel_on_click=True, ax=fig.axes[0])
 
 plt.show()

--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -125,14 +125,19 @@ fig.tight_layout()
 
 #%% Load and plot Neuropixels 2.0 ProbeInterface probe group
 
-fig, (ax_a, ax_b) = plt.subplots(1, 2)
-fig.set_size_inches(6, 8)
-
 np2_config_a = probeinterface.io.read_probeinterface(os.path.join(data_directory, 'np2-config-a.json'))
-probeinterface.plotting.plot_probegroup(np2_config_a, show_channel_on_click=True, ax=fig.axes[0])
-ax_a.set_title('Neuropixels 2.0 Probe A')
 # np2_config_b = probeinterface.io.read_probeinterface(os.path.join(data_directory, 'np2-config-b.json'))
+
+fig = plt.figure()
+
+plt.subplot(121)
+ax_a = plt.gca()
+probeinterface.plotting.plot_probegroup(np2_config_a, show_channel_on_click=True, ax=ax_a)
+plt.title('Neuropixels 2.0 Probe A')
+
+plt.subplot(122)
+ax_b = plt.gca()
 # probeinterface.plotting.plot_probegroup(np2_config_b, show_channel_on_click=True, ax=ax_b)
-ax_b.set_title('Neuropixels 2.0 Probe B')
+plt.title('Neuropixels 2.0 Probe B')
 
 plt.show()

--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -11,6 +11,8 @@ import probeinterface.plotting
 suffix = 0                                                 # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/np2e' # Change to match files' directory
 plot_num_channels = 10                                     # Number of channels to plot
+start_t = 5.0                                              # Plot start time (seconds)
+dur = 2.0                                                  # Plot time duration (seconds)
 
 # Neuropixels 2.0 constants
 fs_hz = 30e3
@@ -42,6 +44,8 @@ rec_a = se.read_binary(os.path.join(data_directory, f'np2-a-ephys_{suffix}.raw')
                      offset_to_uV=offset_to_uV)
 np2_a['ephys_uV'] = rec_a.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
+np2_a_time_mask = np.bitwise_and(np2_a['time'] >= start_t, np2_a['time'] < start_t + dur)
+
 #%% Load Neuropixels 2.0 Probe B data
 
 # np2_b = {}
@@ -58,6 +62,8 @@ np2_a['ephys_uV'] = rec_a.get_traces(return_scaled=True, channel_ids=np.arange(p
 #                      offset_to_uV=offset_to_uV)
 # np2_b['data_uV'] = rec_b.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
+# np2_b_time_mask = np.bitwise_and(np2_b['time'] >= start_t, np2_b['time'] < start_t + dur)
+
 #%% Load BNO055 data
 
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
@@ -67,46 +73,49 @@ bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), del
 # Convert clock cycles to seconds
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
+bno055_time_mask = np.bitwise_and(bno055_time >= start_t, bno055_time < start_t + dur)
+
 #%% Plot time series
 
 fig = plt.figure(figsize=(12, 8))
 
 # Plot scaled Neuropixels 2.0 probe A data
 plt.subplot(611)
-plt.plot(np2_a['time'], np2_a['ephys_uV'])
+plt.plot(np2_a['time'][np2_a_time_mask], np2_a['ephys_uV'][np2_a_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
 plt.title('Neuropixels 2.0  Probe A')
 
 # Plot scaled Neuropixels 2.0 probe B data
 plt.subplot(612)
-# plt.plot(np2_b['time'], np2_b['data_uV'])
+# plt.plot(np2_b['time'][np2_b_time_mask], np2_b['data_uV'][np2_b_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
 plt.title('Neuropixels 2.0 Probe B')
 
 # Plot BNO055 data
 plt.subplot(613)
-plt.plot(bno055_time, bno055['euler'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['euler'].squeeze()[bno055_time_mask])
+plt.xlabel('Time (seconds)')
 plt.ylabel('degrees')
 plt.title('Euler Angles')
 plt.legend(['Yaw', 'Pitch', 'Roll'])
 
 plt.subplot(614)
-plt.plot(bno055_time, bno055['quat'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['quat'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.title('Quaternion')
 plt.legend(['X', 'Y', 'Z', 'W'])
 
 plt.subplot(615)
-plt.plot(bno055_time, bno055['accel'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['accel'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Linear Acceleration')
 plt.legend(['X', 'Y', 'Z'])
 
 plt.subplot(616)
-plt.plot(bno055_time, bno055['grav'].squeeze())
+plt.plot(bno055_time[bno055_time_mask], bno055['grav'].squeeze()[bno055_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Gravity Vector')

--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -6,75 +6,106 @@ import spikeinterface.extractors as se
 import probeinterface
 import probeinterface.plotting
 
-# Parameters
-suffix = 0                                                 # Change to match file names' suffix
+#%% Set parameters for loading data
+
+suffix = 0                                                 # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/np2e' # Change to match files' directory
 plot_num_channels = 10                                     # Number of channels to plot
 
-# Constants
+# Neuropixels 2.0 constants
 fs_hz = 30e3
 gain_to_uV = 3.05176
 offset_to_uV = -2048 * gain_to_uV
 num_channels = 384
 
-# Load acquisition session data
+#%%  Load acquisition session data
+
 dt = {'names': ('time', 'acq_clk_hz', 'block_read_sz', 'block_write_sz'),
       'formats': ('datetime64[us]', 'u4', 'u4', 'u4')}
 meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt, skip_header=1)
 print(f'Recording was started at {meta["time"]} GMT')
 print(f'Acquisition clock rate was {meta["acq_clk_hz"] / 1e6 } MHz')
 
-# Load Neuropixels 2.0 clock data
-rec_time = np.fromfile(os.path.join(data_directory, f'np2-a-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
+#%% Load Neuropixels 2.0 Probe A data
 
-# Load and scale Neuropixels 2.0 ephys data
-rec = se.read_binary(os.path.join(data_directory, f'np2-a-ephys_{suffix}.raw'),
+np2_a = {}
+
+# Load Neuropixels 2.0 probe A time data and convert clock cycles to seconds
+np2_a['time'] = np.fromfile(os.path.join(data_directory, f'np2-a-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
+
+# Load and scale Neuropixels 2.0 probe A ephys data
+rec_a = se.read_binary(os.path.join(data_directory, f'np2-a-ephys_{suffix}.raw'),
                      sampling_frequency=fs_hz,
                      dtype=np.uint16,
                      num_channels=num_channels,
                      gain_to_uV=gain_to_uV,
                      offset_to_uV=offset_to_uV)
-rec_scaled = rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
+np2_a['ephys_uV'] = rec_a.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
-# Load BNO055 data
+#%% Load Neuropixels 2.0 Probe B data
+
+# np2_b = {}
+
+# Load Neuropixels 2.0 probe B time data and convert clock cycles to seconds
+# np2_b['time'] = np.fromfile(os.path.join(data_directory, f'np2-b-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
+
+# # Load and scale Neuropixels 2.0 probe B ephys data
+# rec_b = se.read_binary(os.path.join(data_directory, f'np2-b-ephys_{suffix}.raw'),
+#                      sampling_frequency=fs_hz,
+#                      dtype=np.uint16,
+#                      num_channels=num_channels,
+#                      gain_to_uV=gain_to_uV,
+#                      offset_to_uV=offset_to_uV)
+# np2_b['data_uV'] = rec_b.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
+
+#%% Load BNO055 data
+
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
       'formats': ('u8', '(1,3)f8', '(1,4)f8', '?', '(1,3)f8', '(1,3)f8', 'f8')}
 bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), delimiter=',', dtype=dt)
 
-# BNO055 time data
+# Convert clock cycles to seconds
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
-# Plot time series
+#%% Plot time series
+
 fig = plt.figure(figsize=(12, 8))
 
-# Plot scaled Neuropixels 2.0 data
-plt.subplot(511)
-plt.plot(rec_time, rec_scaled)
+# Plot scaled Neuropixels 2.0 probe A data
+plt.subplot(611)
+plt.plot(np2_a['time'], np2_a['ephys_uV'])
 plt.xlabel('Time (seconds)')
 plt.ylabel('µV')
-plt.title('Neuropixels 2.0 Voltage')
+plt.title('Neuropixels 2.0  Probe A')
+
+# Plot scaled Neuropixels 2.0 probe B data
+plt.subplot(612)
+# plt.plot(np2_b['time'], np2_b['data_uV'])
+plt.xlabel('Time (seconds)')
+plt.ylabel('µV')
+plt.title('Neuropixels 2.0 Probe B')
 
 # Plot BNO055 data
-plt.subplot(512)
+plt.subplot(613)
 plt.plot(bno055_time, bno055['euler'].squeeze())
 plt.ylabel('degrees')
 plt.title('Euler Angles')
 plt.legend(['Yaw', 'Pitch', 'Roll'])
 
-plt.subplot(513)
+plt.subplot(614)
 plt.plot(bno055_time, bno055['quat'].squeeze())
 plt.xlabel('Time (seconds)')
 plt.title('Quaternion')
 plt.legend(['X', 'Y', 'Z', 'W'])
 
-plt.subplot(514)
+plt.subplot(615)
 plt.plot(bno055_time, bno055['accel'].squeeze())
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
 plt.title('Linear Acceleration')
 plt.legend(['X', 'Y', 'Z'])
 
-plt.subplot(515)
+plt.subplot(616)
 plt.plot(bno055_time, bno055['grav'].squeeze())
 plt.xlabel('Time (seconds)')
 plt.ylabel('m/s\u00b2')
@@ -83,8 +114,16 @@ plt.legend(['X', 'Y', 'Z'])
 
 fig.tight_layout()
 
-# Load and plot Neuropixels 2.0 probeinterface probe group
-np2_config = probeinterface.io.read_probeinterface(os.path.join(data_directory, 'np2-config.json'))
-probeinterface.plotting.plot_probegroup(np2_config, show_channel_on_click=True)
+#%% Load and plot Neuropixels 2.0 ProbeInterface probe group
+
+fig, (ax_a, ax_b) = plt.subplots(1, 2)
+fig.set_size_inches(6, 8)
+
+np2_config_a = probeinterface.io.read_probeinterface(os.path.join(data_directory, 'np2-config-a.json'))
+probeinterface.plotting.plot_probegroup(np2_config_a, show_channel_on_click=True, ax=fig.axes[0])
+ax_a.set_title('Neuropixels 2.0 Probe A')
+# np2_config_b = probeinterface.io.read_probeinterface(os.path.join(data_directory, 'np2-config-b.json'))
+# probeinterface.plotting.plot_probegroup(np2_config_b, show_channel_on_click=True, ax=ax_b)
+ax_b.set_title('Neuropixels 2.0 Probe B')
 
 plt.show()

--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -1,102 +1,90 @@
+# Import necessary packages
 import os
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.patches as mpatches
 import spikeinterface.extractors as se
-import spikeinterface.widgets as sw
 import probeinterface
 import probeinterface.plotting
 
-suffix = 0 # Change to match file names' suffix
-num_channels = 384 # Decrease channels to expedite plotting and inspect fewer traces
-# Change this to the directory of your data. In this example, data's in the same directory as this data loading Python script
-data_directory = os.path.dirname(os.path.realpath(__file__)) 
-mode = 'auto' # This uses colormap plot above 50 channels and line plot below 50 channels. Refer to the spikeinterface docs for more options
-# Change this to the name of your probeinterface file (should be in the same directory as the rest of your data for this example script to work as-is)
-probeinterface_filename = 'np2-config.json'
+# Parameters
+suffix = 0                                                 # Change to match file names' suffix
+data_directory = 'C:/Users/open-ephys/Documents/data/np2e' # Change to match files' directory
+plot_num_channels = 10                                     # Number of channels to plot
 
-plt.close('all')
+# Constants
+fs_hz = 30e3
+gain_to_uV = 3.05176
+offset_to_uV = -2048 * gain_to_uV
+num_channels = 384
 
-#%% Metadata
+# Load acquisition session data
 dt = {'names': ('time', 'acq_clk_hz', 'block_read_sz', 'block_write_sz'),
       'formats': ('datetime64[us]', 'u4', 'u4', 'u4')}
 meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt, skip_header=1)
-print(f"Recording was started at {meta['time']} GMT")
+print(f'Recording was started at {meta["time"]} GMT')
+print(f'Acquisition clock rate was {meta["acq_clk_hz"] / 1e6 } MHz')
 
-#%% Neuropixels 1.0 probeinterface
-fig, ax = plt.subplots()
-np2_config = probeinterface.io.read_probeinterface(os.path.join(data_directory, probeinterface_filename))
-contacts_colors = ['cyan' if device_channel_index > -1 else 'red' for device_channel_index in np2_config.probes[0].device_channel_indices]
-probeinterface.plotting.plot_probegroup(np2_config, ax=ax, contacts_colors=contacts_colors, contacts_kargs={'alpha' : 1, 'zorder' : 10}, show_channel_on_click=True)
-fig.set_size_inches(2, 9)
-enabled = mpatches.Patch(color='cyan', label='Enabled')
-disabled = mpatches.Patch(color='red', label='Disabled')
-fig.legend(handles=[enabled, disabled], loc='outside upper center') 
-plt.tight_layout()
+# Load Neuropixels 2.0 clock data
+rec_time = np.fromfile(os.path.join(data_directory, f'np2-a-clock_{suffix}.raw'), dtype=np.uint64).astype(np.double) / meta['acq_clk_hz']
 
-#%% Neuropixels 2.0 Data
-bit_depth = 12
-scalar = 3.05176
-offset = -(2 ** (bit_depth - 1)) * scalar
-recording = se.read_binary(os.path.join(data_directory,  f"np2-a-ephys_{suffix}.raw"), 
-                           3e5, 
-                           np.uint16, 
-                           num_channels, 
-                           gain_to_uV=scalar, 
-                           offset_to_uV=-offset) 
-traces_plot = sw.plot_traces(recording, 
-                   backend='matplotlib', 
-                   return_scaled=True, 
-                   mode=mode, 
-                   clim=(-offset,offset),
-                   figsize=(6,9),
-                   figtitle='Neuropixels 2.0 Data')
-ax.set_xlabel("time (sec)")
-ax.set_ylabel("Ephys (µV)")
+# Load and scale Neuropixels 2.0 ephys data
+rec = se.read_binary(os.path.join(data_directory, f'np2-a-ephys_{suffix}.raw'),
+                     sampling_frequency=fs_hz,
+                     dtype=np.uint16,
+                     num_channels=num_channels,
+                     gain_to_uV=gain_to_uV,
+                     offset_to_uV=offset_to_uV)
+rec_scaled = rec.get_traces(return_scaled=True, channel_ids=np.arange(plot_num_channels))
 
-#%% Bno055
+# Load BNO055 data
 dt = {'names': ('clock', 'euler', 'quat', 'is_quat_id', 'accel', 'grav', 'temp'),
       'formats': ('u8', '(1,3)f8', '(1,4)f8', '?', '(1,3)f8', '(1,3)f8', 'f8')}
 bno055 = np.genfromtxt(os.path.join(data_directory, f'bno055_{suffix}.csv'), delimiter=',', dtype=dt)
 
+# BNO055 time data
 bno055_time = bno055['clock'] / meta['acq_clk_hz']
 
-plt.figure()
-plt.subplot(231)
+# Plot time series
+fig = plt.figure(figsize=(12, 8))
+
+# Plot scaled Neuropixels 2.0 data
+plt.subplot(511)
+plt.plot(rec_time, rec_scaled)
+plt.xlabel('Time (seconds)')
+plt.ylabel('µV')
+plt.title('Neuropixels 2.0 Voltage')
+
+# Plot BNO055 data
+plt.subplot(512)
 plt.plot(bno055_time, bno055['euler'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("angle (deg.)")
-plt.ylim(-185, 365)
-plt.legend(['yaw', 'pitch', 'roll'])
-plt.title('Euler')
+plt.ylabel('degrees')
+plt.title('Euler Angles')
+plt.legend(['Yaw', 'Pitch', 'Roll'])
 
-plt.subplot(232)
+plt.subplot(513)
 plt.plot(bno055_time, bno055['quat'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylim(-1.1, 1.1)
-plt.legend(['X', 'Y', 'Z', 'W'])
+plt.xlabel('Time (seconds)')
 plt.title('Quaternion')
+plt.legend(['X', 'Y', 'Z', 'W'])
 
-plt.subplot(233)
+plt.subplot(514)
 plt.plot(bno055_time, bno055['accel'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("accel. (m/s^2)")
+plt.xlabel('Time (seconds)')
+plt.ylabel('m/s\u00b2')
+plt.title('Linear Acceleration')
 plt.legend(['X', 'Y', 'Z'])
-plt.title('Lin. Accel.')
 
-plt.subplot(234)
+plt.subplot(515)
 plt.plot(bno055_time, bno055['grav'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("accel. (m/s^2)")
+plt.xlabel('Time (seconds)')
+plt.ylabel('m/s\u00b2')
+plt.title('Gravity Vector')
 plt.legend(['X', 'Y', 'Z'])
-plt.title('Gravity Vec.')
 
-plt.subplot(235)
-plt.plot(bno055_time, bno055['temp'].squeeze())
-plt.xlabel("time (sec)")
-plt.ylabel("temp. (°C)")
-plt.title('Headstage Temp.')
+fig.tight_layout()
 
-plt.tight_layout()
+# Load and plot Neuropixels 2.0 probeinterface probe group
+np2_config = probeinterface.io.read_probeinterface(os.path.join(data_directory, 'np2-config.json'))
+probeinterface.plotting.plot_probegroup(np2_config, show_channel_on_click=True)
 
-fig.suptitle('BNO055 Data')
+plt.show()

--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -11,7 +11,7 @@ import probeinterface.plotting
 suffix = 0                                                 # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/np2e' # Change to match files' directory
 plot_num_channels = 10                                     # Number of channels to plot
-start_t = 5.0                                              # Plot start time (seconds)
+start_t = 3.0                                              # Plot start time (seconds)
 dur = 2.0                                                  # Plot time duration (seconds)
 
 # Neuropixels 2.0 constants

--- a/workflows/hardware/rhs2116/load-rhs2116.py
+++ b/workflows/hardware/rhs2116/load-rhs2116.py
@@ -8,6 +8,8 @@ import matplotlib.pyplot as plt
 suffix = 0                                                    # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/rhs2116' # Change to match files' directory
 plot_num_channels = 10                                        # Number of channels to plot
+start_t = 5.0                                                 # Plot start time (seconds)
+dur = 2.0                                                     # Plot time duration (seconds)
 
 # RHS2116 constants
 ac_uV_multiplier = 0.195
@@ -39,20 +41,22 @@ rhs2116['ac_uV'] = (ac.astype(np.float32) - ac_offset) * ac_uV_multiplier
 dc = np.reshape(np.fromfile(os.path.join(data_directory, f'rhs2116-dc_{suffix}.raw'), dtype=np.uint16), (-1, num_channels))
 rhs2116['dc_uV'] = (dc.astype(np.float32) - dc_offset) * dc_uV_multiplier
 
+rhs2116_time_mask = np.bitwise_and(rhs2116['time'] >= start_t, rhs2116['time'] < start_t + dur)
+
 #%% Plot time series
 
 fig = plt.figure()
 
 # Plot RHS2116 AC data
 plt.subplot(211)
-plt.plot(rhs2116['time'], rhs2116['ac_uV'][:,0:plot_num_channels])
+plt.plot(rhs2116['time'][rhs2116_time_mask], rhs2116['ac_uV'][:,0:plot_num_channels][rhs2116_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('Voltage (µV)')
 plt.title('RHS2116 AC Data')
 
 # Plot RHS2116 DC data
 plt.subplot(212)
-plt.plot(rhs2116['time'], rhs2116['dc_uV'][:,0:plot_num_channels])
+plt.plot(rhs2116['time'][rhs2116_time_mask], rhs2116['dc_uV'][:,0:plot_num_channels][rhs2116_time_mask])
 plt.xlabel('Time (seconds)')
 plt.ylabel('Voltage (µV)')
 plt.title('RHS2116 DC Data')

--- a/workflows/hardware/rhs2116/load-rhs2116.py
+++ b/workflows/hardware/rhs2116/load-rhs2116.py
@@ -8,13 +8,13 @@ import matplotlib.pyplot as plt
 suffix = 0                                                    # Change to match filenames' suffix
 data_directory = 'C:/Users/open-ephys/Documents/data/rhs2116' # Change to match files' directory
 plot_num_channels = 10                                        # Number of channels to plot
-start_t = 5.0                                                 # Plot start time (seconds)
+start_t = 3.0                                                 # Plot start time (seconds)
 dur = 2.0                                                     # Plot time duration (seconds)
 
 # RHS2116 constants
 ac_uV_multiplier = 0.195
 ac_offset = 32768
-dc_uV_multiplier = -19.23
+dc_mV_multiplier = -19.23
 dc_offset = 512
 num_channels = 32 # for two RHS2116 devices per headstage
 
@@ -39,13 +39,13 @@ rhs2116['ac_uV'] = (ac.astype(np.float32) - ac_offset) * ac_uV_multiplier
 
 # Load and scale RHS2116 DC data
 dc = np.reshape(np.fromfile(os.path.join(data_directory, f'rhs2116-dc_{suffix}.raw'), dtype=np.uint16), (-1, num_channels))
-rhs2116['dc_uV'] = (dc.astype(np.float32) - dc_offset) * dc_uV_multiplier
+rhs2116['dc_mV'] = (dc.astype(np.float32) - dc_offset) * dc_mV_multiplier
 
 rhs2116_time_mask = np.bitwise_and(rhs2116['time'] >= start_t, rhs2116['time'] < start_t + dur)
 
 #%% Plot time series
 
-fig = plt.figure()
+fig = plt.figure(figsize=(12, 6))
 
 # Plot RHS2116 AC data
 plt.subplot(211)
@@ -56,9 +56,9 @@ plt.title('RHS2116 AC Data')
 
 # Plot RHS2116 DC data
 plt.subplot(212)
-plt.plot(rhs2116['time'][rhs2116_time_mask], rhs2116['dc_uV'][:,0:plot_num_channels][rhs2116_time_mask])
+plt.plot(rhs2116['time'][rhs2116_time_mask], rhs2116['dc_mV'][:,0:plot_num_channels][rhs2116_time_mask])
 plt.xlabel('Time (seconds)')
-plt.ylabel('Voltage (µV)')
+plt.ylabel('Voltage (mV)')
 plt.title('RHS2116 DC Data')
 
 plt.tight_layout()

--- a/workflows/hardware/rhs2116/load-rhs2116.py
+++ b/workflows/hardware/rhs2116/load-rhs2116.py
@@ -1,62 +1,62 @@
+# Import necessary packages
 import os
 import numpy as np
 import matplotlib.pyplot as plt
 
-plt.close('all')
+#%% Set parameters for loading data
 
-#%% Set Parameters for Loading Data
+suffix = 0                                                    # Change to match filenames' suffix
+data_directory = 'C:/Users/open-ephys/Documents/data/rhs2116' # Change to match files' directory
+plot_num_channels = 10                                        # Number of channels to plot
 
-suffix = '0'; # Change to match file names' suffix
-# Change this to the directory of your data. In this example, data's in the same directory as this data loading Python script
-data_directory = os.path.dirname(os.path.realpath(__file__))
-start_t = 1.0 # when to start plotting data (seconds)
-dur = 1.0 # duration of data to plot
+# RHS2116 constants
+ac_uV_multiplier = 0.195
+ac_offset = 32768
+dc_uV_multiplier = -19.23
+dc_offset = 512
+num_channels = 32 # for two RHS2116 devices per headstage
 
-#%% Metadata
+#%%  Load acquisition session data
 
 dt = {'names': ('time', 'acq_clk_hz', 'block_read_sz', 'block_write_sz'),
       'formats': ('datetime64[us]', 'u4', 'u4', 'u4')}
-meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt)
+meta = np.genfromtxt(os.path.join(data_directory, f'start-time_{suffix}.csv'), delimiter=',', dtype=dt, skip_header=1)
 print(f"Recording was started at {meta['time']} GMT")
+print(f'Acquisition clock rate was {meta["acq_clk_hz"] / 1e6 } MHz')
 
-#%% RHS2116 ephys data
-
-start_t = 1.0 # when to start plotting data (seconds)
-dur = 1.0 # duration of data to plot
+#%% Load RHS2116 data
 
 rhs2116 = {}
+
+# Load RHS2116 clock data and convert clock cycles to seconds
 rhs2116['time'] = np.fromfile(os.path.join(data_directory, f'rhs2116-clock_{suffix}.raw'), dtype=np.uint64) / meta['acq_clk_hz']
-b = np.bitwise_and(rhs2116['time'] >= start_t, rhs2116['time'] < start_t + dur)
-time = rhs2116['time'][b]
 
-# AC data
-rhs2116['ac'] = np.reshape(np.fromfile(os.path.join(data_directory, f'rhs2116-ac_{suffix}.raw'), dtype=np.uint16), (-1, 32))
-rhs2116_ac = rhs2116['ac'][b, :].astype(np.double)
-bit_depth = 16
-scalar = 0.195
-offset = (2 ** (bit_depth - 1)) * scalar
-rhs2116_ac_converted = rhs2116_ac * scalar - offset + np.arange(rhs2116_ac.shape[1])[None, :] * offset / 4
+# Load and scale RHS2116 AC data
+ac = np.reshape(np.fromfile(os.path.join(data_directory, f'rhs2116-ac_{suffix}.raw'), dtype=np.uint16), (-1, num_channels))
+rhs2116['ac_uV'] = (ac.astype(np.float32) - ac_offset) * ac_uV_multiplier
 
-# DC data
-rhs2116['dc'] = np.reshape(np.fromfile(os.path.join(data_directory, f'rhs2116-dc_{suffix}.raw'), dtype=np.uint16), (-1, 32))
-rhs2116_dc = rhs2116['dc'][b, :].astype(np.double)
-bit_depth = 10
-scalar = -19.23
-offset = (2 ** (bit_depth - 1)) * -scalar
-rhs2116_dc_converted = rhs2116_dc * scalar - offset + np.arange(rhs2116_dc.shape[1])[None, :] * offset / 4
+# Load and scale RHS2116 DC data
+dc = np.reshape(np.fromfile(os.path.join(data_directory, f'rhs2116-dc_{suffix}.raw'), dtype=np.uint16), (-1, num_channels))
+rhs2116['dc_uV'] = (dc.astype(np.float32) - dc_offset) * dc_uV_multiplier
 
-def setup_subplot(ax):
-      ax.set_yticks([])
-      ax.set_ylabel("channel")
-      ax.set_xlabel("time (s)")
+#%% Plot time series
 
-fig, (ax_ac, ax_dc) = plt.subplots(nrows=1, ncols=2, figsize=(10,8))
-ax_ac.plot(time, rhs2116_ac_converted, 'k', linewidth=0.25)
-ax_ac.set_title('RHS2116 AC Data')
-setup_subplot(ax_ac)
-ax_dc.plot(time, rhs2116_dc_converted, 'k', linewidth=0.25)
-ax_dc.set_title('RHS2116 DC Data')
-setup_subplot(ax_dc)
-fig.suptitle('RHS2116 Data')
+fig = plt.figure()
+
+# Plot RHS2116 AC data
+plt.subplot(211)
+plt.plot(rhs2116['time'], rhs2116['ac_uV'][:,0:plot_num_channels])
+plt.xlabel('Time (seconds)')
+plt.ylabel('Voltage (µV)')
+plt.title('RHS2116 AC Data')
+
+# Plot RHS2116 DC data
+plt.subplot(212)
+plt.plot(rhs2116['time'], rhs2116['dc_uV'][:,0:plot_num_channels])
+plt.xlabel('Time (seconds)')
+plt.ylabel('Voltage (µV)')
+plt.title('RHS2116 DC Data')
+
 plt.tight_layout()
+
 plt.show()


### PR DESCRIPTION
- Sample rate set to 30e3
- Gains set to default values for np1 (1000 for AP & 50 for LFP)
- Load data with spikeinterface, use matplotlib to plot
- Reduce plot customizations
- Reduce dependencies

- This commit updates the submodule to point to [e4d8998](https://github.com/open-ephys/bonsai-onix1/commit/e4d89984d07175d08b2701b013ed7523a29d815c) which fixes broken references to the ONI spec docs.
---
- Resolve #202 
- Resolve #214