### PR TITLE
Include plural in hyperlink text

### DIFF
--- a/articles/hardware/breakout/analog-io.md
+++ b/articles/hardware/breakout/analog-io.md
@@ -73,7 +73,8 @@ does exactly this on analog IO channel 0.
 :::
 
 The <xref:OpenEphys.Onix1.AnalogInput> operator receives a sequence of
-<xref:OpenEphys.Onix1.AnalogInputDataFrame>s with the following properties settings:
+[AnalogInputDataFrames](xref:OpenEphys.Onix1.AnalogInputDataFrame) with the following properties
+settings:
 
 - `BufferSize` is set to 50. Therefore, each frame will contain a 50-element
   `Clock` vector and a 12-channel x 50-sample `AnalogData` matrix. The analog inputs are sampled at

--- a/articles/hardware/hs64/estim.md
+++ b/articles/hardware/hs64/estim.md
@@ -10,11 +10,12 @@ triggering a train of pulses following a press of the △ key on the breakout bo
 ![/workflows/hardware/hs64/estim.bonsai workflow](../../../workflows/hardware/hs64/estim.bonsai)
 :::
 
-The <xref:OpenEphys.Onix1.DigitalInput> operator generates a sequence of <xref:OpenEphys.Onix1.DigitalInputDataFrame>s.
-Although the digital inputs are sampled at 4 Mhz, these data frames are only emitted when the port status changes (i.e.,
-when a pin, button, or switch is toggled). In the Breakout Board example workflow, the `DigitalInput`'s `DeviceName`
-property is set to "BreakoutBoard/DigitalInput". This links the `DigitalInput` operator to the corresponding
-configuration operator. 
+The <xref:OpenEphys.Onix1.DigitalInput> operator generates a sequence of
+[DigitalInputDataFrames](xref:OpenEphys.Onix1.DigitalInputDataFrame). Although the digital inputs
+are sampled at 4 Mhz, these data frames are only emitted when the port status changes (i.e., when a
+pin, button, or switch is toggled). In the Breakout Board example workflow, the `DigitalInput`'s
+`DeviceName` property is set to "BreakoutBoard/DigitalInput". This links the `DigitalInput` operator
+to the corresponding configuration operator. 
 
 <xref:OpenEphys.Onix1.BreakoutButtonState> is selected from the `DigitalInputDataFrame`. It is an enumerator with values
 that correspond to bit positions of the breakout board's digital port. When this type is connected to a `HasFlags`

--- a/articles/hardware/hs64/ostim.md
+++ b/articles/hardware/hs64/ostim.md
@@ -10,11 +10,12 @@ triggering a train of pulses following a press of the ◯ key on the breakout bo
 ![/workflows/hardware/hs64/ostim.bonsai workflow](../../../workflows/hardware/hs64/ostim.bonsai)
 :::
 
-The <xref:OpenEphys.Onix1.DigitalInput> operator generates a sequence of <xref:OpenEphys.Onix1.DigitalInputDataFrame>s.
-Although the digital inputs are sampled at 4 Mhz, these data frames are only emitted when the port status changes (i.e.,
-when a pin, button, or switch is toggled). In the Breakout Board example workflow, the `DigitalInput`'s `DeviceName`
-property is set to "BreakoutBoard/DigitalInput". This links the `DigitalInput` operator to the corresponding
-configuration operator. 
+The <xref:OpenEphys.Onix1.DigitalInput> operator generates a sequence of
+[DigitalInputDataFrames](xref:OpenEphys.Onix1.DigitalInputDataFrame). Although the digital inputs
+are sampled at 4 Mhz, these data frames are only emitted when the port status changes (i.e., when a
+pin, button, or switch is toggled). In the Breakout Board example workflow, the `DigitalInput`'s
+`DeviceName` property is set to "BreakoutBoard/DigitalInput". This links the `DigitalInput` operator
+to the corresponding configuration operator. 
 
 <xref:OpenEphys.Onix1.BreakoutButtonState> is selected from the `DigitalInputDataFrame`. It is an enumerator with values
 that correspond to bit positions of the breakout board's digital port. When this type is connected to a `HasFlags`

--- a/articles/hardware/hs64/rhd2164.md
+++ b/articles/hardware/hs64/rhd2164.md
@@ -10,8 +10,8 @@ streaming and saving data from the Rhd2164 device.
 ![/workflows/hardware/hs64/rhd2164.bonsai workflow](../../../workflows/hardware/hs64/rhd2164.bonsai)
 :::
 
-The <xref:OpenEphys.Onix1.Rhd2164Data> operator generates a sequence of <xref:OpenEphys.Onix1.Rhd2164DataFrame>s using
-the following properties settings:
+The <xref:OpenEphys.Onix1.Rhd2164Data> operator generates a sequence of
+[Rhd2164DataFrames](xref:OpenEphys.Onix1.Rhd2164DataFrame) using the following properties settings:
 - `BufferSize` is set to 30. Each `Rhd2164DataFrame` will contain a [1 x 30 sample] `Clock` vector, a [64 channel x 30
   sample] `AmplifierData` matrix, and a [3 channel x 30 sample] `AuxData` matrix. This corresponds to 1 ms of data per
   data frame.

--- a/articles/hardware/np1e/np1.md
+++ b/articles/hardware/np1e/np1.md
@@ -12,7 +12,8 @@ functionality by streaming and saving probe data.
 :::
 
 The <xref:OpenEphys.Onix1.NeuropixelsV1eData> operator generates a sequence of
-<xref:OpenEphys.Onix1.NeuropixelsV1DataFrame>s using the following properties settings:
+[NeuropixelsV1DataFrames](xref:OpenEphys.Onix1.NeuropixelsV1DataFrame) using the following
+properties settings:
 - `BufferSize` is set to 36. Therefore, each frame will contain a [1 x 36 sample] `Clock` vector, a [384
   channel x 36 sample] `SpikeData` matrix, and a [384 channel x 3 sample] `LfpData` matrix. The Neuropixels 1.0 probe
   samples AP data at 30 kHz per channel (LFP data is sampled at a rate of 1/12 of the rate AP data) so this corresponds

--- a/articles/hardware/np2e/np2.md
+++ b/articles/hardware/np2e/np2.md
@@ -20,7 +20,8 @@ press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd>, or click `Enable` right-cli
 :::
 
 The <xref:OpenEphys.Onix1.NeuropixelsV2eData> operator generates a sequence of
-<xref:OpenEphys.Onix1.NeuropixelsV2eDataFrame>s using the following properties settings:
+[NeuropixelsV2eDataFrames](xref:OpenEphys.Onix1.NeuropixelsV2eDataFrame) using the following
+properties settings:
 - `BufferSize` is set to 30. Therefore, each frame will contain a [1 x 30 sample] `Clock` vector and a [384 channel x 30
   sample] `AmplifierData` matrix. The Neuropixels 2.0 probe samples at 30 kHz per channel so this corresponds to 1 ms of
   data.

--- a/articles/hardware/rhs2116/rhs2116-record.md
+++ b/articles/hardware/rhs2116/rhs2116-record.md
@@ -21,11 +21,10 @@ settings:
 - The DeviceName property is set to "HeadstageRhs2116/Rhs2116". This links
   `Rhs2116PairData` to the Rhs2116s on the Headstage Rhs2116.
 
-The relevant properties are extracted from the
-<xref:OpenEphys.Onix1.Rhs2116PairDataFrame> by right-clicking the `Rhs2116PairData`
-operator, and choosing the following Output members: Clock, AmplifierData, and
-DcData. The <xref:Bonsai.Dsp.MatrixWriter>s save the selected members to files
-with the following formats: `rhs2116pair-clock_<filecount>.raw`,
+The relevant properties are extracted from the <xref:OpenEphys.Onix1.Rhs2116PairDataFrame> by
+right-clicking the `Rhs2116PairData` operator, and choosing the following Output members: Clock,
+AmplifierData, and DcData. The [MatrixWriters](xref:Bonsai.Dsp.MatrixWriter) save the selected
+members to files with the following formats: `rhs2116pair-clock_<filecount>.raw`,
 `rhs2116pair-ac_<filecount>.raw`, `rhs2116pair-dc_<filecount>.raw`, and
 `rhs2116pair-recovery_<filecount>.raw` respectively.
 

--- a/articles/hardware/rhs2116/rhs2116-stimulate.md
+++ b/articles/hardware/rhs2116/rhs2116-stimulate.md
@@ -11,11 +11,11 @@ stimulation functionality by streaming and saving data from the Rhs2116 device.
 :::
 
 The <xref:OpenEphys.Onix1.DigitalInput> operator generates a sequence of
-<xref:OpenEphys.Onix1.DigitalInputDataFrame>s. Although the digital inputs are sampled at 4 Mhz,
-these data frames are only emitted when the port status changes (i.e., when a pin, button, or switch
-is toggled). In the example workflow, the `DigitalInput`'s DeviceName property is
-set to "BreakoutBoard/DigitalInput". This links the `DigitalInput` operator to the Breakout Board's
-digital inputs. 
+[DigitalInputDataFrames](xref:OpenEphys.Onix1.DigitalInputDataFrame). Although the digital inputs
+are sampled at 4 Mhz, these data frames are only emitted when the port status changes (i.e., when a
+pin, button, or switch is toggled). In the example workflow, the `DigitalInput`'s DeviceName
+property is set to "BreakoutBoard/DigitalInput". This links the `DigitalInput` operator to the
+Breakout Board's digital inputs. 
 
 <xref:OpenEphys.Onix1.BreakoutButtonState> is selected from the `DigitalInputDataFrame`. It is an
 enumerator with values that correspond to bit positions of the breakout board's digital port.

--- a/articles/hardware/ucla-miniscope-v4/camera.md
+++ b/articles/hardware/ucla-miniscope-v4/camera.md
@@ -12,7 +12,7 @@ the user to dynamically modifying camera parameters.
 :::
 
 The <xref:OpenEphys.Onix1.UclaMiniscopeV4CameraData> operator generates a sequence of
-<xref:OpenEphys.Onix1.UclaMiniscopeV4CameraFrame>s using the following properties settings:
+[UclaMiniscopeV4CameraFrames](xref:OpenEphys.Onix1.UclaMiniscopeV4CameraFrame) using the following properties settings:
 - `DataType` is set to "U8". This sets the bit depth of each pixel in the image to eight (instead of ten if `DataType`
   is set to "U10")
 - `DeviceName` is set to "UclaMiniscopeV4/UclaMiniscopeV4". This links the `UclaMiniscopeV4CameraData` operator to the


### PR DESCRIPTION
I requested both @jonnew & @bparks13, though a single review from whomever gets to it first is sufficient. I just requested both in case one of you is particularly eager to take look at it.

---

I used the following command `git grep '<xref:[^>]*>s'` to find all instances of text that follows the undesired pattern and then manually re-wrote them.

---

Fix #252 

