### PR TITLE
Add comments to np data-loading scripts about inverting polarity

### DIFF
--- a/workflows/hardware/np1e/load-np1e.py
+++ b/workflows/hardware/np1e/load-np1e.py
@@ -16,11 +16,14 @@ lfp_gain = 50                                              # Change to the lfp b
 start_t = 3.0                                              # Plot start time (seconds)
 dur = 2.0                                                  # Plot time duration (seconds)
 
+# If the "Invert Polarity" checkbox was unchecked in the configuration GUI when data was collected,
+# set the value below as negative instead of positive
+sample_gain = 1171.875
+
 # Neuropixels 1.0 constants
 fs_hz_ap = 30e3
 fs_hz_lfp = fs_hz_ap / 12
 sample_offset = 512
-sample_gain = 1171.875
 num_channels = 384
 
 #%%  Load acquisition session data

--- a/workflows/hardware/np2e/load-np2e.py
+++ b/workflows/hardware/np2e/load-np2e.py
@@ -14,10 +14,13 @@ plot_num_channels = 10                                     # Number of channels 
 start_t = 3.0                                              # Plot start time (seconds)
 dur = 2.0                                                  # Plot time duration (seconds)
 
+# If the "Invert Polarity" checkbox was unchecked in the configuration GUI when data was collected,
+# set the value below as negative instead of positive
+gain_to_uV = 3.05176
+
 # Neuropixels 2.0 constants
 fs_hz = 30e3
-gain_to_uV = 3.05176
-offset_to_uV = -2048 * gain_to_uV
+offset_to_uV = -2048 * gain_to_uV 
 num_channels = 384
 
 #%%  Load acquisition session data


### PR DESCRIPTION
If data was not inverted through the configuration GUI, the user needs to multiply neuropixels data by -1

fix #246